### PR TITLE
Fixes ScalerFuture's state machine issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ dask-worker-space/*
 
 build*/
 CMakeUserPresets.json
+CMakeFiles/
 .vs/

--- a/scaler/client/agent/client_agent.py
+++ b/scaler/client/agent/client_agent.py
@@ -13,7 +13,8 @@ from scaler.client.agent.heartbeat_manager import ClientHeartbeatManager
 from scaler.client.agent.object_manager import ClientObjectManager
 from scaler.client.agent.task_manager import ClientTaskManager
 from scaler.client.serializer.mixins import Serializer
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
+from scaler.io.async_connector import ZMQAsyncConnector
 from scaler.protocol.python.common import ObjectStorageAddress
 from scaler.protocol.python.message import (
     ClientDisconnect,
@@ -63,7 +64,7 @@ class ClientAgent(threading.Thread):
 
         self._future_manager = future_manager
 
-        self._connector_internal = AsyncConnector(
+        self._connector_internal: AsyncConnector = ZMQAsyncConnector(
             context=zmq.asyncio.Context.shadow(self._context),
             name="client_agent_internal",
             socket_type=zmq.PAIR,
@@ -72,7 +73,7 @@ class ClientAgent(threading.Thread):
             callback=self.__on_receive_from_client,
             identity=None,
         )
-        self._connector_external = AsyncConnector(
+        self._connector_external: AsyncConnector = ZMQAsyncConnector(
             context=zmq.asyncio.Context.shadow(self._context),
             name="client_agent_external",
             socket_type=zmq.DEALER,

--- a/scaler/client/agent/disconnect_manager.py
+++ b/scaler/client/agent/disconnect_manager.py
@@ -1,7 +1,7 @@
 from typing import Optional
 
 from scaler.client.agent.mixins import DisconnectManager
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
 from scaler.protocol.python.message import ClientDisconnect, ClientShutdownResponse
 from scaler.utility.exceptions import ClientQuitException, ClientShutdownException
 

--- a/scaler/client/agent/future_manager.py
+++ b/scaler/client/agent/future_manager.py
@@ -28,9 +28,14 @@ class ClientFutureManager(FutureManager):
 
     def cancel_all_futures(self):
         with self._lock:
-            logging.info(f"canceling {len(self._task_id_to_future)} task(s)")
-            for task_id, future in self._task_id_to_future.items():
-                future.cancel()
+            futures_to_cancel = list(self._task_id_to_future.values())
+
+        # Actually cancelling the futures should occur without holding the future manager's lock. That's because
+        # `cancel()` is blocking, and requires the manager to process result and cancel confirm messages.
+
+        logging.info(f"canceling {len(futures_to_cancel)} task(s)")
+        for future in futures_to_cancel:
+            future.cancel()
 
     def set_all_futures_with_exception(self, exception: Exception):
         with self._lock:

--- a/scaler/client/agent/heartbeat_manager.py
+++ b/scaler/client/agent/heartbeat_manager.py
@@ -5,7 +5,7 @@ from typing import Optional
 import psutil
 
 from scaler.client.agent.mixins import HeartbeatManager, ObjectManager
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
 from scaler.protocol.python.common import ObjectStorageAddress
 from scaler.protocol.python.message import ClientHeartbeat, ClientHeartbeatEcho
 from scaler.protocol.python.status import Resource

--- a/scaler/client/agent/object_manager.py
+++ b/scaler/client/agent/object_manager.py
@@ -1,7 +1,7 @@
 from typing import Optional, Set
 
 from scaler.client.agent.mixins import ObjectManager
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
 from scaler.protocol.python.common import ObjectMetadata
 from scaler.protocol.python.message import ObjectInstruction, TaskResult
 from scaler.utility.identifiers import ClientID, ObjectID

--- a/scaler/client/agent/task_manager.py
+++ b/scaler/client/agent/task_manager.py
@@ -2,7 +2,7 @@ from typing import Optional, Set
 
 from scaler.client.agent.future_manager import ClientFutureManager
 from scaler.client.agent.mixins import ObjectManager, TaskManager
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
 from scaler.protocol.python.message import GraphTask, GraphTaskCancel, Task, TaskCancel, TaskResult, TaskCancelConfirm
 
 

--- a/scaler/client/future.py
+++ b/scaler/client/future.py
@@ -12,9 +12,9 @@ from scaler.utility.metadata.profile_result import ProfileResult
 from scaler.utility.serialization import deserialize_failure
 
 
-class ScalerFuture(Future):
-    """ScalerFuture is just trying to mimic the API of standard python future, it doesn't behave exactly as python
-    future
+class ScalerFuture(concurrent.futures.Future):
+    """
+    A drop-in replacement for Python's `concurrent.futures.Future`.
 
     e.g.: if future.cancel, standard python future will immediately get canceled without get cancel confirmation, but
     scaler future will require future confirmation so after future.cancel, it will not immediately get canceled

--- a/scaler/client/future.py
+++ b/scaler/client/future.py
@@ -3,8 +3,7 @@ from concurrent.futures import Future, InvalidStateError
 from typing import Any, Callable, Optional
 
 from scaler.client.serializer.mixins import Serializer
-from scaler.io.sync_connector import SyncConnector
-from scaler.io.sync_object_storage_connector import SyncObjectStorageConnector
+from scaler.io.mixins import SyncConnector, SyncObjectStorageConnector
 from scaler.protocol.python.common import TaskState
 from scaler.protocol.python.message import Task, TaskCancel
 from scaler.utility.event_list import EventList

--- a/scaler/client/object_buffer.py
+++ b/scaler/client/object_buffer.py
@@ -5,8 +5,7 @@ from typing import Any, Callable, List, Optional, Set
 import cloudpickle
 
 from scaler.client.serializer.mixins import Serializer
-from scaler.io.sync_connector import SyncConnector
-from scaler.io.sync_object_storage_connector import SyncObjectStorageConnector
+from scaler.io.mixins import SyncConnector, SyncObjectStorageConnector
 from scaler.protocol.python.common import ObjectMetadata
 from scaler.protocol.python.message import ObjectInstruction
 from scaler.utility.identifiers import ClientID, ObjectID

--- a/scaler/entry_points/top.py
+++ b/scaler/entry_points/top.py
@@ -3,7 +3,7 @@ import curses
 import functools
 from typing import Dict, List, Literal, Union
 
-from scaler.io.sync_subscriber import SyncSubscriber
+from scaler.io.sync_subscriber import ZMQSyncSubscriber
 from scaler.protocol.python.message import StateScheduler
 from scaler.protocol.python.mixins import Message
 from scaler.utility.formatter import (
@@ -50,7 +50,7 @@ def poke(screen, args):
     screen.nodelay(1)
 
     try:
-        subscriber = SyncSubscriber(
+        subscriber = ZMQSyncSubscriber(
             address=ZMQConfig.from_string(args.address),
             callback=functools.partial(show_status, screen=screen),
             topic=b"",

--- a/scaler/io/async_binder.py
+++ b/scaler/io/async_binder.py
@@ -8,13 +8,13 @@ import zmq.asyncio
 from zmq import Frame
 
 from scaler.io.utility import deserialize, serialize
+from scaler.io.mixins import AsyncBinder
 from scaler.protocol.python.mixins import Message
 from scaler.protocol.python.status import BinderStatus
-from scaler.utility.mixins import Looper, Reporter
 from scaler.utility.zmq_config import ZMQConfig
 
 
-class AsyncBinder(Looper, Reporter):
+class ZMQAsyncBinder(AsyncBinder):
     def __init__(self, context: zmq.asyncio.Context, name: str, address: ZMQConfig, identity: Optional[bytes] = None):
         self._address = address
 

--- a/scaler/io/async_object_storage_connector.py
+++ b/scaler/io/async_object_storage_connector.py
@@ -3,13 +3,14 @@ import logging
 import socket
 from typing import Dict, Optional, Tuple
 
+from scaler.io.mixins import AsyncObjectStorageConnector
 from scaler.protocol.capnp._python import _object_storage  # noqa
 from scaler.protocol.python.object_storage import ObjectRequestHeader, ObjectResponseHeader, to_capnp_object_id
 from scaler.utility.exceptions import ObjectStorageException
 from scaler.utility.identifiers import ObjectID
 
 
-class AsyncObjectStorageConnector:
+class PyAsyncObjectStorageConnector(AsyncObjectStorageConnector):
     """An asyncio connector that uses an raw TCP socket to connect to a Scaler's object storage instance."""
 
     def __init__(self):

--- a/scaler/io/sync_connector.py
+++ b/scaler/io/sync_connector.py
@@ -8,11 +8,12 @@ from typing import Optional
 import zmq
 
 from scaler.io.utility import deserialize, serialize
+from scaler.io.mixins import SyncConnector
 from scaler.protocol.python.mixins import Message
 from scaler.utility.zmq_config import ZMQConfig
 
 
-class SyncConnector:
+class ZMQSyncConnector(SyncConnector):
     def __init__(self, context: zmq.Context, socket_type: int, address: ZMQConfig, identity: Optional[bytes]):
         self._address = address
 
@@ -34,12 +35,12 @@ class SyncConnector:
 
         self._lock = threading.Lock()
 
-    def close(self):
+    def destroy(self):
         self._socket.close()
 
     @property
-    def address(self) -> ZMQConfig:
-        return self._address
+    def address(self) -> str:
+        return self._address.to_address()
 
     @property
     def identity(self) -> bytes:

--- a/scaler/io/sync_object_storage_connector.py
+++ b/scaler/io/sync_object_storage_connector.py
@@ -3,6 +3,7 @@ import socket
 from threading import Lock
 from typing import Optional, Iterable, List, Tuple
 
+from scaler.io.mixins import SyncObjectStorageConnector
 from scaler.protocol.capnp._python import _object_storage  # noqa
 from scaler.protocol.python.object_storage import ObjectRequestHeader, ObjectResponseHeader, to_capnp_object_id
 from scaler.utility.exceptions import ObjectStorageException
@@ -12,7 +13,7 @@ from scaler.utility.identifiers import ObjectID
 MAX_CHUNK_SIZE = 128 * 1024 * 1024
 
 
-class SyncObjectStorageConnector:
+class PySyncObjectStorageConnector(SyncObjectStorageConnector):
     """An synchronous connector that uses an raw TCP socket to connect to a Scaler's object storage instance."""
 
     def __init__(self, host: str, port: int):

--- a/scaler/io/sync_subscriber.py
+++ b/scaler/io/sync_subscriber.py
@@ -4,12 +4,13 @@ from typing import Callable, Optional
 
 import zmq
 
+from scaler.io.mixins import SyncSubscriber
 from scaler.io.utility import deserialize
 from scaler.protocol.python.mixins import Message
 from scaler.utility.zmq_config import ZMQConfig
 
 
-class SyncSubscriber(threading.Thread):
+class ZMQSyncSubscriber(SyncSubscriber, threading.Thread):
     def __init__(
         self,
         address: ZMQConfig,
@@ -39,7 +40,7 @@ class SyncSubscriber(threading.Thread):
     def __stop_polling(self):
         self._stop_event.set()
 
-    def disconnect(self):
+    def destroy(self):
         self.__stop_polling()
 
     def run(self) -> None:

--- a/scaler/scheduler/controllers/balance_controller.py
+++ b/scaler/scheduler/controllers/balance_controller.py
@@ -1,8 +1,7 @@
 import logging
 from typing import Dict, List, Optional
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector
 from scaler.protocol.python.message import StateBalanceAdvice
 from scaler.scheduler.allocate_policy.mixins import TaskAllocatePolicy
 from scaler.scheduler.controllers.config_controller import VanillaConfigController

--- a/scaler/scheduler/controllers/client_controller.py
+++ b/scaler/scheduler/controllers/client_controller.py
@@ -2,8 +2,7 @@ import logging
 import time
 from typing import Dict, Optional, Set, Tuple
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector
 from scaler.protocol.python.message import (
     ClientDisconnect,
     ClientHeartbeat,

--- a/scaler/scheduler/controllers/graph_controller.py
+++ b/scaler/scheduler/controllers/graph_controller.py
@@ -4,9 +4,7 @@ import enum
 from asyncio import Queue
 from typing import Dict, List, Optional, Set, Tuple, Union
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.common import ObjectMetadata, TaskCancelConfirmType, TaskResultType
 from scaler.protocol.python.message import (
     GraphTask,

--- a/scaler/scheduler/controllers/information_controller.py
+++ b/scaler/scheduler/controllers/information_controller.py
@@ -2,8 +2,7 @@ from typing import Optional
 
 import psutil
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector
 from scaler.protocol.python.message import StateScheduler, InformationRequest
 from scaler.protocol.python.status import Resource
 from scaler.scheduler.controllers.config_controller import VanillaConfigController

--- a/scaler/scheduler/controllers/object_controller.py
+++ b/scaler/scheduler/controllers/object_controller.py
@@ -3,9 +3,7 @@ import logging
 from asyncio import Queue
 from typing import Optional, Set
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.common import ObjectMetadata
 from scaler.protocol.python.message import ObjectInstruction
 from scaler.protocol.python.status import ObjectManagerStatus

--- a/scaler/scheduler/controllers/task_controller.py
+++ b/scaler/scheduler/controllers/task_controller.py
@@ -253,7 +253,8 @@ class VanillaTaskController(TaskController, Looper, Reporter):
         assert state_machine.current_state() == TaskState.Canceled
 
         if task_cancel_confirm.task_id in self._unassigned:
-            pass  # if task is not assigned to any worker, we don't need to deal with worker manager
+            # if task is not assigned to any worker, we don't need to deal with worker manager
+            self._unassigned.remove(task_cancel_confirm.task_id)
         else:
             await self._worker_controller.on_task_done(task_cancel_confirm.task_id)
 

--- a/scaler/scheduler/controllers/task_controller.py
+++ b/scaler/scheduler/controllers/task_controller.py
@@ -3,8 +3,7 @@ import logging
 from collections import deque
 from typing import Awaitable, Callable, Optional, Dict, Any, Deque, Tuple, List
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector
 from scaler.protocol.python.common import TaskResultType, TaskCancelConfirmType, TaskState, TaskTransition
 from scaler.protocol.python.message import StateTask, Task, TaskCancel, TaskResult, TaskCancelConfirm
 from scaler.protocol.python.status import TaskManagerStatus

--- a/scaler/scheduler/controllers/worker_controller.py
+++ b/scaler/scheduler/controllers/worker_controller.py
@@ -2,8 +2,7 @@ import logging
 import time
 from typing import Dict, Optional, Set, Tuple
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector
 from scaler.protocol.python.message import (
     ClientDisconnect,
     DisconnectRequest,

--- a/scaler/scheduler/scheduler.py
+++ b/scaler/scheduler/scheduler.py
@@ -4,9 +4,10 @@ import logging
 
 import zmq.asyncio
 
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector, AsyncObjectStorageConnector
+from scaler.io.async_binder import ZMQAsyncBinder
+from scaler.io.async_connector import ZMQAsyncConnector
+from scaler.io.async_object_storage_connector import PyAsyncObjectStorageConnector
 from scaler.io.config import CLEANUP_INTERVAL_SECONDS, STATUS_REPORT_INTERVAL_SECONDS
 from scaler.protocol.python.common import ObjectStorageAddress
 from scaler.protocol.python.message import (
@@ -69,13 +70,13 @@ class Scheduler:
 
         self._context = zmq.asyncio.Context(io_threads=config.io_threads)
 
-        self._binder = AsyncBinder(context=self._context, name="scheduler", address=config.address)
-        logging.info(f"{self.__class__.__name__}: listen to scheduler address {config.address.to_address()}")
+        self._binder: AsyncBinder = ZMQAsyncBinder(context=self._context, name="scheduler", address=config.address)
+        logging.info(f"{self.__class__.__name__}: listen to scheduler address {config.address}")
 
-        self._connector_storage = AsyncObjectStorageConnector()
+        self._connector_storage: AsyncObjectStorageConnector = PyAsyncObjectStorageConnector()
         logging.info(f"{self.__class__.__name__}: connect to object storage server {object_storage_address!r}")
 
-        self._binder_monitor = AsyncConnector(
+        self._binder_monitor: AsyncConnector = ZMQAsyncConnector(
             context=self._context,
             name="scheduler_monitor",
             socket_type=zmq.PUB,

--- a/scaler/ui/webui.py
+++ b/scaler/ui/webui.py
@@ -4,7 +4,7 @@ from functools import partial
 
 from nicegui import ui
 
-from scaler.io.sync_subscriber import SyncSubscriber
+from scaler.io.sync_subscriber import ZMQSyncSubscriber
 from scaler.protocol.python.message import StateScheduler, StateTask
 from scaler.protocol.python.mixins import Message
 from scaler.ui.constants import (
@@ -75,7 +75,7 @@ def start_webui(address: str, host: str, port: int):
         with ui.tab_panel(settings_tab):
             tables.settings_section.draw_section()
 
-    subscriber = SyncSubscriber(
+    subscriber = ZMQSyncSubscriber(
         address=ZMQConfig.from_string(address),
         callback=partial(__show_status, tables=tables),
         topic=b"",

--- a/scaler/worker/agent/heartbeat_manager.py
+++ b/scaler/worker/agent/heartbeat_manager.py
@@ -3,8 +3,7 @@ from typing import Optional, Set
 
 import psutil
 
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.message import Resource, WorkerHeartbeat, WorkerHeartbeatEcho
 from scaler.protocol.python.status import ProcessorStatus
 from scaler.utility.mixins import Looper

--- a/scaler/worker/agent/processor/streaming_buffer.py
+++ b/scaler/worker/agent/processor/streaming_buffer.py
@@ -1,7 +1,7 @@
 import io
 import logging
 
-from scaler.io.sync_connector import SyncConnector
+from scaler.io.mixins import SyncConnector
 from scaler.protocol.python.message import TaskLog
 from scaler.utility.identifiers import TaskID
 

--- a/scaler/worker/agent/processor_manager.py
+++ b/scaler/worker/agent/processor_manager.py
@@ -5,9 +5,7 @@ from typing import Dict, List, Optional, Tuple
 import tblib.pickling_support
 
 # from scaler.utility.logging.utility import setup_logger
-from scaler.io.async_binder import AsyncBinder
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncBinder, AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.common import ObjectMetadata, TaskResultType
 from scaler.protocol.python.message import ObjectInstruction, ProcessorInitialized, Task, TaskResult
 from scaler.utility.exceptions import ProcessorDiedError

--- a/scaler/worker/agent/task_manager.py
+++ b/scaler/worker/agent/task_manager.py
@@ -1,6 +1,6 @@
 from typing import Dict, Optional, Set
 
-from scaler.io.async_connector import AsyncConnector
+from scaler.io.mixins import AsyncConnector
 from scaler.protocol.python.common import TaskCancelConfirmType
 from scaler.protocol.python.message import Task, TaskCancel, TaskResult, TaskCancelConfirm
 from scaler.utility.identifiers import TaskID

--- a/scaler/worker/symphony/heartbeat_manager.py
+++ b/scaler/worker/symphony/heartbeat_manager.py
@@ -3,8 +3,7 @@ from typing import Optional
 
 import psutil
 
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.message import Resource, WorkerHeartbeat, WorkerHeartbeatEcho
 from scaler.utility.mixins import Looper
 from scaler.utility.object_storage_config import ObjectStorageConfig

--- a/scaler/worker/symphony/task_manager.py
+++ b/scaler/worker/symphony/task_manager.py
@@ -7,8 +7,7 @@ import cloudpickle
 from bidict import bidict
 
 from scaler import Serializer
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncConnector, AsyncObjectStorageConnector
 from scaler.protocol.python.common import ObjectMetadata, ObjectStorageAddress, TaskResultType, TaskCancelConfirmType
 from scaler.protocol.python.message import ObjectInstruction, Task, TaskCancel, TaskResult, TaskCancelConfirm
 from scaler.utility.identifiers import ObjectID, TaskID

--- a/scaler/worker/symphony/worker.py
+++ b/scaler/worker/symphony/worker.py
@@ -7,8 +7,8 @@ from typing import Optional
 import zmq
 import zmq.asyncio
 
-from scaler.io.async_connector import AsyncConnector
-from scaler.io.async_object_storage_connector import AsyncObjectStorageConnector
+from scaler.io.mixins import AsyncConnector, AsyncObjectStorageConnector
+from scaler.io.async_connector import ZMQAsyncConnector
 from scaler.protocol.python.message import (
     ClientDisconnect,
     DisconnectRequest,
@@ -81,7 +81,7 @@ class SymphonyWorker(multiprocessing.get_context("spawn").Process):  # type: ign
         register_event_loop(self._event_loop)
 
         self._context = zmq.asyncio.Context()
-        self._connector_external = AsyncConnector(
+        self._connector_external = ZMQAsyncConnector(
             context=self._context,
             name=self.name,
             socket_type=zmq.DEALER,

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -34,7 +34,6 @@ class TestFuture(unittest.TestCase):
 
     def tearDown(self) -> None:
         self.cluster.shutdown()
-        pass
 
     def test_callback(self):
         done_called_event = Event()

--- a/tests/test_future.py
+++ b/tests/test_future.py
@@ -1,10 +1,20 @@
 import math
+import threading
 import time
 import unittest
-from concurrent.futures import CancelledError, as_completed
+from concurrent.futures import CancelledError, InvalidStateError, as_completed
 from threading import Event
+from typing import Tuple
+from unittest.mock import Mock
 
 from scaler import Client, SchedulerClusterCombo
+from scaler.client.future import ScalerFuture
+from scaler.client.serializer.default import DefaultSerializer
+from scaler.io.mixins import SyncConnector, SyncObjectStorageConnector
+from scaler.protocol.python.common import TaskState
+from scaler.protocol.python.message import Task
+from scaler.utility.exceptions import WorkerDiedError
+from scaler.utility.identifiers import ClientID, ObjectID, TaskID
 from scaler.utility.logging.utility import setup_logger
 from scaler.utility.network_util import get_available_tcp_port
 from tests.utility import logging_test_name
@@ -92,3 +102,203 @@ class TestFuture(unittest.TestCase):
 
         with self.assertRaises(CancelledError):
             fut.result()
+
+    def test_mocked_success(self):
+        task_result = "Task result"
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=task_result)
+
+        # Future should be running
+
+        self.assertTrue(future.running())
+        self.assertFalse(future.done())
+        self.assertFalse(future.cancelled())
+
+        with self.assertRaises(TimeoutError):
+            future.result(timeout=0)
+
+        with self.assertRaises(TimeoutError):
+            future.exception(timeout=0)
+
+        # Future is done, but result should not have been fetched yet
+
+        future.set_result_ready(ObjectID.generate_object_id(client_id), TaskState.Success)
+
+        self.assertFalse(future.running())
+        self.assertTrue(future.done())
+        self.assertFalse(future.cancelled())
+
+        connector_storage.get_object.assert_not_called()
+        connector_storage.delete_object.assert_not_called()
+
+        # Future is done, the result should have been fetched, then deleted
+
+        self.assertEqual(future.result(), task_result)
+        self.assertIsNone(future.exception())
+
+        connector_storage.get_object.assert_called_once()
+        connector_storage.delete_object.assert_called_once()
+
+        # Cannot cancel a finished future
+
+        self.assertFalse(future.cancel())
+
+    def test_mocked_as_completed(self):
+        """Ensure that a task result notifies as_completed waiters."""
+
+        task_result = "Task result"
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=task_result)
+
+        it = as_completed([future])
+
+        future.set_result_ready(ObjectID.generate_object_id(client_id), TaskState.Success)
+
+        # The iterator should yield the finished future
+
+        finished = next(it)
+        self.assertEqual(finished.result(), task_result)
+
+    def test_mocked_task_failure(self):
+        exception = ValueError()
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=exception)
+
+        # Future is failing with an exception, the exception object has been fetched
+
+        future.set_result_ready(ObjectID.generate_object_id(client_id), TaskState.Failed)
+
+        self.assertFalse(future.running())
+        self.assertTrue(future.done())
+        self.assertFalse(future.cancelled())
+
+        connector_storage.get_object.assert_not_called()
+        connector_storage.delete_object.assert_not_called()
+
+        # Future is done and the exception has been fetched, then deleted
+
+        self.assertRaises(ValueError, future.result)
+        self.assertIsInstance(future.exception(), ValueError)
+
+        connector_storage.get_object.assert_called_once()
+        connector_storage.delete_object.assert_called_once()
+
+        # Cannot cancel a failed future
+
+        self.assertFalse(future.cancel())
+
+    def test_mocked_worker_failure(self):
+        exception = WorkerDiedError()
+
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=exception)
+
+        # Future is failing with a local exception, shouldn't reach the object-storage server.
+
+        future.set_exception(exception)
+
+        self.assertFalse(future.running())
+        self.assertTrue(future.done())
+        self.assertFalse(future.cancelled())
+
+        self.assertRaises(WorkerDiedError, future.result)
+        self.assertIsInstance(future.exception(), WorkerDiedError)
+
+        connector_storage.get_object.assert_not_called()
+        connector_storage.delete_object.assert_not_called()
+
+    def test_mocked_cancel(self):
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=None)
+
+        # Cancel the future
+
+        # Mock the client immediately receiving the cancel confirmation after the task cancellation request
+        def on_connector_send(_message):
+            threading.Thread(target=future.set_canceled).start()
+
+        _connector_agent.send.side_effect = on_connector_send
+
+        self.assertTrue(future.cancel())
+
+        self.assertFalse(future.running())
+        self.assertTrue(future.done())
+        self.assertTrue(future.cancelled())
+
+        self.assertRaises(CancelledError, future.result)
+        self.assertRaises(CancelledError, future.exception)
+
+        # Receiving a future result from the scheduler should not change the cancelled state.
+        # That might happen if the future get cancelled while the cluster is finishing the task's computation.
+
+        with self.assertRaises(InvalidStateError):
+            future.set_result_ready(ObjectID.generate_object_id(client_id), TaskState.Success)
+
+        connector_storage.get_object.assert_not_called()
+        connector_storage.delete_object.assert_not_called()
+
+    def test_mocked_cancel_concurrent(self):
+        """
+        Simulate a very specific cancellation case, where the client tries to cancel a future that just finished,
+        but for which it hasn't received the result yet. In this scenario, `future.cancel()` returns `False` and the
+        task finishes normally.
+        """
+
+        task_result = "Task result"
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=task_result)
+        task_result_id = ObjectID.generate_object_id(client_id)
+
+        # Cancel the finishing future
+
+        # Mock the client receiving the task result immediately after the cancellation request
+        def on_connector_send(_message):
+            threading.Thread(target=lambda: future.set_result_ready(task_result_id, TaskState.Success)).start()
+
+        _connector_agent.send.side_effect = on_connector_send
+
+        self.assertFalse(future.cancel())
+
+        self.assertFalse(future.running())
+        self.assertTrue(future.done())
+        self.assertFalse(future.cancelled())
+
+        self.assertEqual(future.result(), task_result)
+
+    def test_mocked_cancel_as_completed(self):
+        """Ensure that a canceled future notifies as_completed waiters."""
+
+        client_id, future, _connector_agent, connector_storage = self.__create_mocked_future(future_result=None)
+
+        it = as_completed([future])
+
+        future.set_canceled()
+
+        # The iterator should yield the canceled future
+
+        finished = next(it)
+        self.assertTrue(finished.cancelled())
+
+    @staticmethod
+    def __create_mocked_future(future_result, is_delayed: bool = True) -> Tuple[ClientID, ScalerFuture, Mock, Mock]:
+        client_id = ClientID.generate_client_id()
+        connector_agent = Mock(spec=SyncConnector)
+        connector_storage = Mock(spec=SyncObjectStorageConnector)
+
+        connector_storage.get_object.return_value = DefaultSerializer.serialize(future_result)
+
+        task = Task.new_msg(
+            task_id=TaskID.generate_task_id(),
+            source=client_id,
+            metadata=b"",
+            func_object_id=ObjectID.generate_object_id(client_id),
+            function_args=[],
+            tags=set(),
+        )
+
+        future = ScalerFuture(
+            task=task,
+            is_delayed=is_delayed,
+            group_task_id=None,
+            serializer=DefaultSerializer(),
+            connector_agent=connector_agent,
+            connector_storage=connector_storage,
+        )
+
+        future.set_running_or_notify_cancel()
+
+        return client_id, future, connector_agent, connector_storage


### PR DESCRIPTION
This rewrites the future logic so that it matches Scaler's new state machine.

**The main change being that `future.cancel()` is now a blocking call**. This ensures that the future's state always matches the task state from the scheduler, while keeping the future API very similar to Python's.

Moreover, the overall synchronization logic of the future is simplified, as it now relies on a single synchronization event instead of two.

In addition, the PR adds new more exhaustive unit tests for the future, and makes all ZMQ connector classes inherit from a base mixin/interface.